### PR TITLE
Error number need to be reset when delete a file

### DIFF
--- a/Sources/File.swift
+++ b/Sources/File.swift
@@ -329,6 +329,7 @@ extension File {
         if rmdir(path) == 0 {
             return
         } else if errno == ENOTDIR {
+            errno = 0
             unlink(path)
         }
         try ensureLastOperationSucceeded()

--- a/Tests/File/FileTests.swift
+++ b/Tests/File/FileTests.swift
@@ -38,6 +38,17 @@ class FileTests: XCTestCase {
             XCTFail()
         }
     }
+    func testDelete() {
+        do {
+            let file = try File(path: "/tmp/zewo-test-file", mode: .truncateReadWrite)
+            let word = "hello"
+            try file.write(word)
+            try file.close()
+            try File.removeItem(at:"/tmp/zewo-test-file")
+        } catch {
+            XCTFail()
+        }
+    }
 
 //    func testFileSize() {
 //        do {
@@ -110,6 +121,7 @@ extension FileTests {
             // ("testFileSize", testFileSize),
             ("testZero", testZero),
             ("testRandom", testRandom),
+            ("testDelete", testDelete),
         ]
         #else
         return [
@@ -118,6 +130,7 @@ extension FileTests {
             // ("testFileSize", testFileSize),
             ("testZero", testZero),
             // ("testRandom", testRandom),
+            ("testDelete", testDelete),
         ]
         #endif
     }


### PR DESCRIPTION
# Error

removeItem(path:”filepath”)
throws ENOTDIR when file path is file
# Reason

errno need to be reset
# Fix

errno = 0 before remove file

Also created test “testDelete” that pass with new commit, but fails
before.
